### PR TITLE
feat: add waitFor config option

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,9 @@ module.exports = {
     ],
 
     globals : {
-        "page" : true,
+        page    : true,
+        browser : true,
+        document : true,
     },
 
     rules : {

--- a/index.js
+++ b/index.js
@@ -2,13 +2,19 @@
 
 const { toMatchSnapshot } = require("jest-snapshot");
 
-module.exports = (page = global.page) => {
+module.exports = ({ page = global.page, waitFor = false } = false) => {
     expect.extend({
-        async toMatchDOMSnapshot(selector, ...args) {
+        async toMatchDOMSnapshot(selector, name, opts = {}) {
             let el = selector;
 
             // Support both string selectors and ElementHandles
             if(typeof selector === "string") {
+                const wait = "waitFor" in opts ? opts.waitFor : waitFor;
+
+                if(wait) {
+                    await page.waitForSelector(selector);
+                }
+
                 el = await page.$(selector);
 
                 if(!el) {
@@ -16,12 +22,13 @@ module.exports = (page = global.page) => {
                 }
             }
 
+            /* istanbul ignore next */
             const source = await page.evaluate((element) => element.outerHTML, el);
 
             return toMatchSnapshot.call(
                 this,
                 source,
-                ...args,
+                name,
             );
         },
     });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,6 @@
 module.exports = {
     preset : "jest-puppeteer",
 
-    setupTestFrameworkScriptFile : "<rootDir>/setup.js",
-
     snapshotSerializers : [
         "jest-serializer-html",
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -2126,7 +2126,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2147,12 +2148,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2173,12 +2176,14 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2323,6 +2328,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2330,12 +2336,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2354,6 +2362,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2447,6 +2456,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2532,7 +2542,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2568,6 +2579,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2587,6 +2599,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2630,12 +2643,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/setup.js
+++ b/setup.js
@@ -1,2 +1,0 @@
-// Install our custom snapshot matcher
-require("./index.js")();

--- a/tests/__snapshots__/options.test.js.snap
+++ b/tests/__snapshots__/options.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.toMatchDOMSnapshot() options should accept a different page instance 1`] = `
+
+<div class="two">
+  TWO
+</div>
+
+`;
+
+exports[`.toMatchDOMSnapshot() options should wait for an element to exist when waitFor is true 1`] = `
+
+<div class="new">
+  NEW
+</div>
+
+`;

--- a/tests/fixtures/two.html
+++ b/tests/fixtures/two.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<body>
+    <div class="two">
+        TWO
+    </div>
+</body>

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,6 +1,10 @@
 "use strict";
 
 describe(".toMatchDOMSnapshot()", () => {
+    beforeAll(() => {
+        require("../index.js")();
+    });
+
     beforeEach(async () => {
         await page.goto(require.resolve("./fixtures/one.html"));
     });

--- a/tests/options.test.js
+++ b/tests/options.test.js
@@ -1,0 +1,39 @@
+"use strict";
+
+const matcher = require("../index.js");
+
+describe(".toMatchDOMSnapshot() options", () => {
+    beforeEach(async () => {
+        await page.goto(require.resolve("./fixtures/one.html"));
+    });
+
+    it("should accept a different page instance", async () => {
+        const two = await browser.newPage();
+
+        await two.goto(require.resolve("./fixtures/two.html"));
+        
+        matcher({ page : two });
+
+        await expect(".two").toMatchDOMSnapshot();
+    });
+
+    it("should wait for an element to exist when waitFor is true", async () => {
+        matcher({ waitFor : true });
+
+        const matching = expect(".new").toMatchDOMSnapshot();
+
+        await page.evaluate(() => {
+            document.body.innerHTML = `<div class="new">NEW</div>`;
+        });
+
+        await matching;
+    });
+    
+    it("should allow overriding the global waitFor setting", async () => {
+        matcher({ waitFor : true });
+
+        const matching = expect(".new").toMatchDOMSnapshot("snap", { waitFor : false });
+
+        await expect(matching).rejects.toThrow("Unable to locate element matching: .new");
+    });
+});


### PR DESCRIPTION
BREAKING CHANGE: instead of directly taking a `page` instance you must now pass `{ page }` to the exported function.

Fixes #1 